### PR TITLE
Add player actions to address threats

### DIFF
--- a/app/dataObjects.js
+++ b/app/dataObjects.js
@@ -7,7 +7,7 @@ const DATA_TYPES = {
     HUMAN_ROOM_UPDATE : "humanRoomUpdate",
     CONSOLE_LINE : "consoleLine",
     GAME_READY : "gameReady",
-    LOBBY_LIST : "lobbyList"
+    LOBBY_LIST : "lobbyList",
     THREAT_SPAWNED: "threatSpawned",
     THREAT_RESOLVED: "threatResolved"
 }
@@ -49,6 +49,4 @@ const ThreatResolvedData = (room) => ({
     room: room
 });
 
-module.exports = { HumanRoomUpdateData, ConsoleLineData, GameReadyData, ThreatSpawnedData, ThreatResolvedData };
-
-module.exports = { HumanRoomUpdateData, ConsoleLineData, GameReadyData, LobbyListData, ThreatSpawnedData };
+module.exports = { HumanRoomUpdateData, ConsoleLineData, GameReadyData, LobbyListData, ThreatSpawnedData, ThreatResolvedData };

--- a/app/dataObjects.js
+++ b/app/dataObjects.js
@@ -9,6 +9,7 @@ const DATA_TYPES = {
     GAME_READY : "gameReady",
     LOBBY_LIST : "lobbyList"
     THREAT_SPAWNED: "threatSpawned",
+    THREAT_RESOLVED: "threatResolved"
 }
 
 const HumanRoomUpdateData = (room) => ({
@@ -43,5 +44,11 @@ const ThreatSpawnedData = (room, threatType, duration, isPaused) => ({
     isPaused,
 });
 
+const ThreatResolvedData = (room) => ({
+    name: DATA_TYPES.THREAT_RESOLVED,
+    room: room
+});
+
+module.exports = { HumanRoomUpdateData, ConsoleLineData, GameReadyData, ThreatSpawnedData, ThreatResolvedData };
 
 module.exports = { HumanRoomUpdateData, ConsoleLineData, GameReadyData, LobbyListData, ThreatSpawnedData };

--- a/app/game/game.js
+++ b/app/game/game.js
@@ -132,16 +132,16 @@ const GAME = (humanUsername, aiUsername, gameId) => {
 
     const removeThreat = (room) => {
         delete THREATS_INDEXED_BY_ROOM[room] // Remove threat
-        AVAILABLE_ROOMS.splice(AVAILABLE_ROOMS.indexOf(room), 1); // Room no longer available
+        ROOMS_WITH_THREATS.splice(ROOMS_WITH_THREATS.indexOf(room), 1); // Removes room from rooms_with_threats
     }
 
     const onThreatUnresolved = (room) => {
         removeThreat(room);
-        ROOMS_WITH_THREATS.splice(ROOMS_WITH_THREATS.indexOf(room), 1); // Removes room from rooms_with_threats
         console.log(`Threat was unresolved room ${room} is no longer available`);
     }
     const onThreatResolved = (room) => {
         removeThreat(room);
+        AVAILABLE_ROOMS.splice(AVAILABLE_ROOMS.indexOf(room), 1); // Room no longer available
         console.log(`Threat was resolved in room ${room}`);
 
         // Alert players threat was resolved

--- a/app/game/game.js
+++ b/app/game/game.js
@@ -129,15 +129,19 @@ const GAME = (humanUsername, aiUsername, gameId) => {
     const alertHumanPlayerOfThreat = (room) => {
         alertPlayerOfThreat(THREATS_INDEXED_BY_ROOM[room], HUMAN_USERNAME, room);
     }
-    const onThreatUnresolved = (room) => {
+
+    const removeThreat = (room) => {
         delete THREATS_INDEXED_BY_ROOM[room] // Remove threat
         AVAILABLE_ROOMS.splice(AVAILABLE_ROOMS.indexOf(room), 1); // Room no longer available
+    }
+
+    const onThreatUnresolved = (room) => {
+        removeThreat(room);
         ROOMS_WITH_THREATS.splice(ROOMS_WITH_THREATS.indexOf(room), 1); // Removes room from rooms_with_threats
         console.log(`Threat was unresolved room ${room} is no longer available`);
     }
     const onThreatResolved = (room) => {
-        delete THREATS_INDEXED_BY_ROOM[room] // Remove threat
-        ROOMS_WITH_THREATS.splice(ROOMS_WITH_THREATS.indexOf(room), 1); // Removes room from rooms_with_threats
+        removeThreat(room);
         console.log(`Threat was resolved in room ${room}`);
 
         // Alert players threat was resolved

--- a/app/game/game.js
+++ b/app/game/game.js
@@ -137,11 +137,11 @@ const GAME = (humanUsername, aiUsername, gameId) => {
 
     const onThreatUnresolved = (room) => {
         removeThreat(room);
+        AVAILABLE_ROOMS.splice(AVAILABLE_ROOMS.indexOf(room), 1); // Room no longer available
         console.log(`Threat was unresolved room ${room} is no longer available`);
     }
     const onThreatResolved = (room) => {
         removeThreat(room);
-        AVAILABLE_ROOMS.splice(AVAILABLE_ROOMS.indexOf(room), 1); // Room no longer available
         console.log(`Threat was resolved in room ${room}`);
 
         // Alert players threat was resolved

--- a/app/game/threat.js
+++ b/app/game/threat.js
@@ -4,16 +4,17 @@ const THREAT_COOLDOWN_SECONDS = 5;
 
 const THREAT_RESOLVE_TIME_MS = 3*1000; // How long it takes when a player enters a room w/ the right tool for the threat to disappear
 
+const MAP_THREAT_TO_TOOL = {
+    "fire" : "fire-extinguisher",
+    "breach" : "wrench",
+    "invader" : "gun"
+}
+
 const Threat = (threatType, onThreatUnresolved, onThreatResolved) => {
     let currentAge = THREAT_TTL;
     const THREAT_TYPE = threatType;
     let resolved = false;
     let isResolving = false;
-    const MAP_THREAT_TO_TOOL = {
-        "fire" : "fire-extinguisher",
-        "breach" : "wrench",
-        "invader" : "gun"
-    }
 
     const tick = () => {
         currentAge -= 1;

--- a/app/game/threat.js
+++ b/app/game/threat.js
@@ -2,23 +2,46 @@ const THREAT_TTL = 30;
 const THREAT_TICK_SPEED = 1000;
 const THREAT_COOLDOWN_SECONDS = 5;
 
-const Threat = (threatType, onThreatUnresolved) => {
+const THREAT_RESOLVE_TIME_MS = 3*1000; // How long it takes when a player enters a room w/ the right tool for the threat to disappear
+
+const Threat = (threatType, onThreatUnresolved, onThreatResolved) => {
     let currentAge = THREAT_TTL;
     const THREAT_TYPE = threatType;
+    let resolved = false;
+    let isResolving = false;
+    const MAP_THREAT_TO_TOOL = {
+        "fire" : "fire-extinguisher",
+        "breach" : "wrench",
+        "invader" : "gun"
+    }
 
     const tick = () => {
         currentAge -= 1;
-        if (currentAge <= 0) {
-            onThreatUnresolved();
-        }
-        else {
+        if (!resolved) {
+            if (currentAge <= 0) {
+                onThreatUnresolved();
+                return;
+            }
             setTimeout(tick, THREAT_TICK_SPEED);
         }
     };
+    /**
+     * Starts a countdown to resolve the threat if the correct tool is passed in
+     * Will call onThreatResolved after a set time has elapsed
+     * Any further calls to resolve after it has started resolving will do nothing
+     */
+    const resolve = (tool) => {
+        const hasCorrectTool = MAP_THREAT_TO_TOOL[threatType] === tool;
+        if (!isResolving && hasCorrectTool) {
+            setTimeout(onThreatResolved, THREAT_RESOLVE_TIME_MS);
+            isResolving = true;
+        }
+    }
     setTimeout(tick, THREAT_TICK_SPEED);
 
     return {
-        THREAT_TYPE
+        THREAT_TYPE,
+        resolve,
     }
 }
 

--- a/app/public/board.js
+++ b/app/public/board.js
@@ -92,6 +92,15 @@ const BOARD = ((rowCount, columnCount) => {
         const roomElement = parseMoveableRoom(room);
         roomElement.setThreat(threatType);
     }
+
+    /**
+     * @param {string} room e.g. "0-0"
+     */
+    const removeThreat = (room) => {
+        ROOMS_WITH_THREATS.splice(ROOMS_WITH_THREATS.indexOf(room), 1);
+        const roomElement = parseMoveableRoom(room);
+        roomElement.setThreat("");
+    }
     
     return {
         setAllToHidden,
@@ -101,6 +110,7 @@ const BOARD = ((rowCount, columnCount) => {
         getSize,
         roomHasThreat,
         spawnThreat,
+        removeThreat,
     };;
 })(3,3);
 

--- a/app/public/receiver.js
+++ b/app/public/receiver.js
@@ -39,5 +39,8 @@ WS.onReceive((data) => {
             break;      
         case "consoleLine":
             CONSOLE.addConsoleLine(data);
+            break;
+        case "threatResolved":
+            BOARD.removeThreat(data.room);
     }
 });


### PR DESCRIPTION
If player enters room with correct tool, the threat will be addressed after 3 seconds (3 seconds for now, we can modify it in the future in play testing).

Note, the current tool selected is Wrench (we have another PR for allowing switching tools). If we enter room with breach, the breach fixes. there's logic to make this work for fire extinguisher and gun too. It's just we can't switch tools yet until the PR for it is in. Note nothing happens when we encounter an alien or a fire, because our current tool is wrench.
https://www.loom.com/share/b10fa66a51bc4a6aa1b11b3d3285d0cb