### PR TITLE
show user stats on lobby page, misc. changes

### DIFF
--- a/app/clientsHandler.js
+++ b/app/clientsHandler.js
@@ -22,7 +22,7 @@ const CLIENTS_HANDLER = (() => {
      */
     const registerClient = (clientId, username, gameId, token) => {
         let loggedIn = false;
-        if (token in tokenStorage) {
+        if (isUserLoggedin(token)) {
             loggedIn = true;
         } 
         REGISTERED_CLIENTS[clientId] = {
@@ -114,6 +114,10 @@ const CLIENTS_HANDLER = (() => {
         }
     }
 
+    const isUserLoggedin = (token) => {
+        return token in tokenStorage;
+    };
+
 
     return {
         CLIENTS,
@@ -124,7 +128,8 @@ const CLIENTS_HANDLER = (() => {
         registerClient,
         doesGameHaveRegisteredClients,
         updatePlayerStats,
-        areBothPlayersLoggedIn
+        areBothPlayersLoggedIn,
+        isUserLoggedin
     }
 })();
 

--- a/app/lobby/lobby.js
+++ b/app/lobby/lobby.js
@@ -84,12 +84,15 @@ const leaveLobby = (lobbyId, username) => {
 			return false;
 		}
         // Removes user
-        if (LOBBIES[lobbyId][0].username === username) {
+        if (LOBBIES[lobbyId][0] !== undefined && LOBBIES[lobbyId][0].username === username) {
             LOBBIES[lobbyId].splice(0, 1);
         }
-		else if (LOBBIES[lobbyId][1].username === username) {
+		else if (LOBBIES[lobbyId][1] !== undefined && LOBBIES[lobbyId][1].username === username) {
             LOBBIES[lobbyId].splice(1, 1);
 		}
+        else {
+            throw Error(`Lobby ${lobbyId} is already empty`);
+        }
         deleteUserFromLobby(username);
 	}
     return true;

--- a/app/public/cookies.js
+++ b/app/public/cookies.js
@@ -8,6 +8,6 @@ const COOKIES = (() => {
     return cookiesObject;
 })();
 
-const USERNAME_COOKIE = COOKIES.username ?? Math.floor(Math.random()*10000);
+const USERNAME_COOKIE = COOKIES.username ?? Math.floor(Math.random()*10000).toString();
 const GAME_ID_COOKIE = COOKIES.gameId ?? null;
 const TOKEN_COOKIE = COOKIES.token ?? null;

--- a/app/public/lobby/index.html
+++ b/app/public/lobby/index.html
@@ -8,6 +8,15 @@
     <title>Cyberspace Saboteur</title>
 </head>
 <body class="body lobbyBody">
+	<header>
+		<div class="header-info">
+			<div id="username" class="header-stat"></div>
+			<div class="header-stat">
+				<div id="wins" class="stat"></div> <!-- W: 0, or empty if anonymous -->
+				<div id="losses" class="stat"></div> <!-- L: 0, or empty if anonymous -->
+			</div>
+		</div>
+	</header>
 	<div class="lobbies" id="lobbies">
 		<!-- Example of what gets populated -->
 		<!-- <div class="lobby"><div class="lobby-title">Lobby 1 (0/2)</div><div class="players"></div><div class="spaceship"></div></div> -->

--- a/app/public/lobby/lobby.css
+++ b/app/public/lobby/lobby.css
@@ -1,3 +1,36 @@
+header {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    position: fixed;
+    width: 100%;
+    height: 6rem;
+    top: 0rem;
+    right: 0rem;
+}
+
+.header-info {
+    width: 12rem;
+    padding: .5rem 1rem;
+}
+
+.header-stat {
+    display: flex;
+    flex-direction: row;
+    font-size: 24px;
+    font-weight: 600;
+    font-family: system-ui;
+    justify-content: right;
+    color: white;
+    height: 50%;
+}
+
+.stat {
+    flex-grow: 50%;
+    justify-content: right;
+    padding: 0rem 0rem 0rem 1rem;
+}
+
 .lobbies {
     flex: 4;
     display: flex;
@@ -77,4 +110,6 @@
 /* Disabled initially if not in lobby */
 #leave-lobby-button {
     display: none;
+    position: fixed;
+    top: 6rem;
 }

--- a/app/public/lobby/lobbyUI.js
+++ b/app/public/lobby/lobbyUI.js
@@ -16,6 +16,9 @@ const updateLobbyData = (updateLobbyData) => {
 
 const lobbies = document.getElementById("lobbies");
 const leaveLobbyButton = document.getElementById("leave-lobby-button");
+const userDiv = document.getElementById("username");
+const winDiv = document.getElementById("wins");
+const loseDiv = document.getElementById("losses");
 
 /**.
  * @param {string[]} classes e.g. ["class1", "class2"]
@@ -91,8 +94,24 @@ const clearLobbies = () => {
     lobbies.innerText = "";
 }
 
+const setUserStatDisplay = (wins, losses) => {
+	// only show wins/losses if player is logged in and has stats
+	if (wins === undefined) {
+		userDiv.innerText = "ANONYMOUS";
+		// these would already be empty, but...
+		winDiv.innerText = "";
+		loseDiv.innerText = "";
+	}
+	else {
+		userDiv.innerText = USERNAME_COOKIE;
+		winDiv.innerText = "W: " + wins.toString();
+		loseDiv.innerText = "L: " + losses.toString();
+	}
+}
+
 const init = () => {
 	getLobbyData();
 	checkIfUserIsInLobby();
+	getUserStats();
 }
 init();

--- a/app/public/lobby/lobbyutils.js
+++ b/app/public/lobby/lobbyutils.js
@@ -94,6 +94,17 @@ const checkIfUserIsInLobby = async () => {
 	}
 }
 
+const getUserStats = async () => {
+	const resp = await get("/lobby/stats");
+	if (resp.status === 200) {
+		const userData = await resp.json();
+		setUserStatDisplay(userData.wins, userData.losses);
+	}
+	else {
+		console.log("ERROR - Something went wrong");
+	}
+}
+
 // Richard - I think the making lobby logic is fun and may be useful in future if lots of players join.
 // But since it's week 9/10, I don't think it'll be worth continuing this logic. It may be simpler to just
 // have prepopulated lobbies and just prevent the user from creating lobbies for now and only being able to join lobbies.

--- a/app/request_handlers/handlers/lobby.js
+++ b/app/request_handlers/handlers/lobby.js
@@ -106,7 +106,7 @@ const lobbyStats = (req, res) => {
 			return res.send(stats);
 		}).catch((error) => {
 			console.error('Error getting player stats:', error);
-			res.statusCode = 400;
+			res.statusCode = 500;
 			return res.send(stats);
 		});
 	}

--- a/app/request_handlers/request_handlers.js
+++ b/app/request_handlers/request_handlers.js
@@ -1,4 +1,4 @@
-const { lobbyJoin, lobbyJoinGame, lobbyLeave, lobbiesGet, lobbyIsJoined } = require("./handlers/lobby.js");
+const { lobbyJoin, lobbyJoinGame, lobbyLeave, lobbiesGet, lobbyIsJoined, lobbyStats, getLeaderboard } = require("./handlers/lobby.js");
 const { createAccount, login } = require("./handlers/login.js");
 
 const setRequestHandlers = (app) => {
@@ -14,6 +14,8 @@ const setRequestHandlers = (app) => {
 	app.post("/lobby/leave", lobbyLeave);
     app.get("/lobby/list", lobbiesGet);
 	app.post("/lobby/isjoined", lobbyIsJoined);
+    app.get("/lobby/stats", lobbyStats);
+    app.get("/lobby/leaderboard", getLeaderboard);
 
     app.post("/login/create", createAccount);
     app.post("/login/login", login)


### PR DESCRIPTION
username, wins, and losses are now displayed in the top right corner if the player is logged in (NOTE: might look funky on mobile or just not be there at all...)

getleaderboard handler to see all usernames and stats with 0 styling

also fixed bug where anonymous players have issues leaving lobbies if their cookie timed out and they received a new one (fix in cookies.js)

leave lobby button follows scroll now